### PR TITLE
Add project settings and launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "desktop": false,
+            "name": "WPILib roboRIO Debug",
+            "request": "launch",
+            "type": "wpilib"
+        },
+        {
+            "desktop": true,
+            "name": "WPILib Desktop Debug",
+            "request": "launch",
+            "type": "wpilib"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "java.format.settings.url": "https://gist.github.com/BrendanBurkhart/e2c5167c18fa5637ba8ee3d1c2a69d16/raw",
+    "java.format.settings.profile": "javaStyle",
+    "java.configuration.updateBuildConfiguration": "automatic",
+}


### PR DESCRIPTION
Project-wide style for Java formatter to enforce consistent formatting
Set Java classpath update mode to auto

Add WPILib default launch configurations

Project-wide settings should generally be kept to a minimum since they will override any settings a specific developer has set. I think standardizing formatting is important enough to warrant being added to project settings. Setting classpath update to auto will help prevent a new programmer from accidentally breaking the build.